### PR TITLE
Develop

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -10228,6 +10224,113 @@
         "line_number": 298
       }
     ],
+    "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "fb1e374c8adbd22c6031bb128bd077d7a854e8b7",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "6d248d9f823a4484938e6270c2f958551c381fb9",
+        "is_verified": false,
+        "line_number": 22
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "0d5789cb3cace2e3dbb3808c5badc06d6d7bd351",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "899e5920ef1372292f1f4f69d3125e5a5f5a1dfb",
+        "is_verified": false,
+        "line_number": 153
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "cdbbf3d0b30d627cedeef2647ff4c677769fd816",
+        "is_verified": false,
+        "line_number": 153
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "3f68c719e1b6fea7c116b525d17f38f30ff45fd5",
+        "is_verified": false,
+        "line_number": 184
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "68f0ae4911f9842018b1005c0687640a6b201442",
+        "is_verified": false,
+        "line_number": 199
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "17f3156773f87c2cbd0e23729afccd602273c172",
+        "is_verified": false,
+        "line_number": 202
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "f61e2af5aa50324b8e15f43b9680b433bba73b84",
+        "is_verified": false,
+        "line_number": 203
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "bd1798f27f65bd92c7dbf8f1f62fba7fb1ddc670",
+        "is_verified": false,
+        "line_number": 227
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "c584a3644f29426cd66e7fda417529388320f3cd",
+        "is_verified": false,
+        "line_number": 251
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "6c4b22f78bde6541ac66a58f711ee4913e941972",
+        "is_verified": false,
+        "line_number": 305
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "df02200bdb6fb7108b9ec4d035c267d5a1011852",
+        "is_verified": false,
+        "line_number": 387
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "95e5c986858c2ff1024b794cd23167ffbaddefd7",
+        "is_verified": false,
+        "line_number": 427
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "c545519cbcbbe6ad278af339465539f6e72bc45c",
+        "is_verified": false,
+        "line_number": 438
+      }
+    ],
     "tests/storage/Storage.Integration-DenyStorageVersion.Tests.ps1": [
       {
         "type": "Base64 High Entropy String",
@@ -10407,6 +10510,78 @@
         "line_number": 206
       }
     ],
+    "tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "6d248d9f823a4484938e6270c2f958551c381fb9",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "f72ce24300d0745424373062d86a2201d1c05c8a",
+        "is_verified": false,
+        "line_number": 181
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "f981fa1e3a5c5e058aa745e07efbb5e88a75cc35",
+        "is_verified": false,
+        "line_number": 182
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "a543b9adafb21f76f6b421efc3dc74c19a5897b1",
+        "is_verified": false,
+        "line_number": 183
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "2dd4a83d012acd714fbd600cfb9847611783fea3",
+        "is_verified": false,
+        "line_number": 290
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "7a602ec7a8779ae5283a2ee5bd81172258eb1d7c",
+        "is_verified": false,
+        "line_number": 302
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "b4bdf0b34fa16cce30c435259c6511e708be12b0",
+        "is_verified": false,
+        "line_number": 320
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "5a03f2d64c1718d64774db8091044670e2c9e21d",
+        "is_verified": false,
+        "line_number": 337
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "e138f66bd2852b071aee3d586cb71765f265ecc9",
+        "is_verified": false,
+        "line_number": 347
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1",
+        "hashed_secret": "ec1e2c6e03f092b4874f51d5bb8b872d4b51f9cb",
+        "is_verified": false,
+        "line_number": 354
+      }
+    ],
     "tests/storage/Storage.Unit-DenyStorageSoftDelete.Tests.ps1": [
       {
         "type": "Base64 High Entropy String",
@@ -10431,5 +10606,5 @@
       }
     ]
   },
-  "generated_at": "2025-10-01T23:41:03Z"
+  "generated_at": "2025-10-01T23:57:35Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -10300,35 +10304,35 @@
         "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
         "hashed_secret": "c584a3644f29426cd66e7fda417529388320f3cd",
         "is_verified": false,
-        "line_number": 251
+        "line_number": 255
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
         "hashed_secret": "6c4b22f78bde6541ac66a58f711ee4913e941972",
         "is_verified": false,
-        "line_number": 305
+        "line_number": 310
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
         "hashed_secret": "df02200bdb6fb7108b9ec4d035c267d5a1011852",
         "is_verified": false,
-        "line_number": 387
+        "line_number": 390
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
         "hashed_secret": "95e5c986858c2ff1024b794cd23167ffbaddefd7",
         "is_verified": false,
-        "line_number": 427
+        "line_number": 430
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1",
         "hashed_secret": "c545519cbcbbe6ad278af339465539f6e72bc45c",
         "is_verified": false,
-        "line_number": 438
+        "line_number": 441
       }
     ],
     "tests/storage/Storage.Integration-DenyStorageVersion.Tests.ps1": [
@@ -10606,5 +10610,5 @@
       }
     ]
   },
-  "generated_at": "2025-10-01T23:57:35Z"
+  "generated_at": "2025-10-02T01:48:50Z"
 }

--- a/tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1
+++ b/tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1
@@ -1,0 +1,511 @@
+#Requires -Modules Pester, Az.Accounts, Az.Resources, Az.Storage, Az.PolicyInsights
+
+<#
+.SYNOPSIS
+    Pester integration tests for the Deny Storage HTTPS Disabled policy
+.DESCRIPTION
+    This test suite validates the Azure Policy definition and tests actual compliance
+    behavior for storage accounts with HTTPS-only traffic settings.
+.NOTES
+    Prerequisites:
+    - Azure PowerShell modules (Az.Accounts, Az.Resources, Az.Storage, Az.PolicyInsights)
+    - Authenticated Azure session with appropriate permissions
+    - Resource group 'rg-azure-policy-testing' must exist
+    - Policy must be assigned to the resource group
+#>
+
+BeforeAll {
+    # Import centralized configuration
+    . "$PSScriptRoot\..\..\config\config-loader.ps1"
+
+    # Initialize test configuration for this specific policy
+    $script:TestConfig = Initialize-PolicyTestConfig -PolicyCategory 'storage' -PolicyName 'deny-storage-https-disabled'
+
+    # Import required modules using centralized configuration
+    Import-PolicyTestModule -ModuleTypes @('Required', 'Storage')
+
+    # Initialize test environment with skip-on-no-context for VS Code Test Explorer
+    $envInit = Initialize-PolicyTestEnvironment -Config $script:TestConfig -SkipIfNoContext $script:TestConfig.Azure.SkipIfNoContext
+    if (-not $envInit.Success) {
+        if ($envInit.ShouldSkip) {
+            # Skip all tests if no Azure context is available
+            Write-Host 'Skipping all tests - no Azure context available' -ForegroundColor Yellow
+            return
+        }
+        throw "Environment initialization failed: $($envInit.Errors -join '; ')"
+    }
+
+    # Set script variables from configuration
+    $script:ResourceGroupName = $script:TestConfig.Azure.ResourceGroupName
+    $script:PolicyName = $script:TestConfig.Policy.Name
+    $script:PolicyDisplayName = $script:TestConfig.Policy.DisplayName
+    $script:TestStoragePrefix = $script:TestConfig.Policy.ResourcePrefix
+
+    # Use context from environment initialization
+    $script:Context = $envInit.Context
+    $script:SubscriptionId = $envInit.SubscriptionId
+    Write-Host "Running tests in subscription: $($script:Context.Subscription.Name) ($script:SubscriptionId)" -ForegroundColor Green
+
+    # Verify resource group exists
+    $script:ResourceGroup = Get-AzResourceGroup -Name $script:ResourceGroupName -ErrorAction SilentlyContinue
+    if (-not $script:ResourceGroup) {
+        throw "Resource group '$script:ResourceGroupName' not found. Please create it first."
+    }
+
+    # Load policy definition from file
+    $policyPath = Get-PolicyDefinitionPath -PolicyCategory 'storage' -PolicyName 'deny-storage-https-disabled' -TestScriptPath $PSScriptRoot
+    if (Test-Path $policyPath) {
+        $script:PolicyDefinitionJson = Get-Content $policyPath -Raw | ConvertFrom-Json
+    }
+    else {
+        throw "Policy definition file not found at: $policyPath"
+    }
+
+    # Storage accounts created during tests
+    $script:CreatedStorageAccounts = @()
+}
+
+Describe 'Policy Definition Validation' -Tag @('Unit', 'Fast', 'PolicyDefinition') {
+    Context 'Policy JSON Structure' {
+        It 'Should have valid policy definition structure' {
+            $script:PolicyDefinitionJson | Should -Not -BeNullOrEmpty
+            $script:PolicyDefinitionJson.properties | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have correct display name' {
+            $script:PolicyDefinitionJson.properties.displayName | Should -Match 'HTTPS'
+        }
+
+        It 'Should have correct policy name' {
+            $script:PolicyDefinitionJson.name | Should -Be $script:PolicyName
+        }
+
+        It 'Should have comprehensive description' {
+            $script:PolicyDefinitionJson.properties.description | Should -Not -BeNullOrEmpty
+            $script:PolicyDefinitionJson.properties.description | Should -Match 'HTTPS'
+        }
+
+        It 'Should have proper metadata' {
+            $metadata = $script:PolicyDefinitionJson.properties.metadata
+            $metadata | Should -Not -BeNullOrEmpty
+            $metadata.category | Should -Be 'Storage'
+            $metadata.version | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should target Microsoft.Storage/storageAccounts resource type' {
+            $policyRule = $script:PolicyDefinitionJson.properties.policyRule
+            $conditions = $policyRule.if.allOf
+
+            $typeCondition = $conditions | Where-Object { $_.field -eq 'type' }
+            $typeCondition | Should -Not -BeNullOrEmpty
+            $typeCondition.equals | Should -Be 'Microsoft.Storage/storageAccounts'
+        }
+
+        It 'Should have effect parameter with correct allowed values' {
+            $effectParam = $script:PolicyDefinitionJson.properties.parameters.effect
+            $effectParam | Should -Not -BeNullOrEmpty
+            $effectParam.allowedValues | Should -Contain 'Audit'
+            $effectParam.allowedValues | Should -Contain 'Deny'
+            $effectParam.allowedValues | Should -Contain 'Disabled'
+            $effectParam.defaultValue | Should -Be 'Deny'
+        }
+
+        It 'Should have exemptedStorageAccounts parameter' {
+            $exemptionsParam = $script:PolicyDefinitionJson.properties.parameters.exemptedStorageAccounts
+            $exemptionsParam | Should -Not -BeNullOrEmpty
+            $exemptionsParam.type | Should -Be 'Array'
+            $exemptionsParam.defaultValue | Should -Be @()
+        }
+
+        It 'Should have storageAccountTypes parameter' {
+            $typesParam = $script:PolicyDefinitionJson.properties.parameters.storageAccountTypes
+            $typesParam | Should -Not -BeNullOrEmpty
+            $typesParam.type | Should -Be 'Array'
+            $typesParam.allowedValues.Count | Should -BeGreaterThan 5
+        }
+
+        It 'Should check supportsHttpsTrafficOnly property' {
+            $policyRule = $script:PolicyDefinitionJson.properties.policyRule
+            $conditions = $policyRule.if.allOf
+            $httpsCondition = $conditions | Where-Object { $_.anyOf }
+
+            $httpsCondition | Should -Not -BeNullOrEmpty
+            $httpsChecks = $httpsCondition.anyOf
+
+            $existsCheck = $httpsChecks | Where-Object {
+                $_.field -eq 'Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly' -and $_.exists -eq 'false'
+            }
+            $falseCheck = $httpsChecks | Where-Object {
+                $_.field -eq 'Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly' -and $_.equals -eq 'false'
+            }
+
+            $existsCheck | Should -Not -BeNullOrEmpty
+            $falseCheck | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have parameterized effect' {
+            $policyRule = $script:PolicyDefinitionJson.properties.policyRule
+            $policyRule.then.effect | Should -Be '[parameters(''effect'')]'
+        }
+    }
+}
+
+Describe 'Policy Assignment Validation' -Tag @('Integration', 'Fast', 'PolicyAssignment') {
+    Context 'Policy Assignment Exists' {
+        BeforeAll {
+            $script:PolicyAssignments = Get-AzPolicyAssignment -Scope $script:ResourceGroup.ResourceId
+            $script:TargetAssignment = $script:PolicyAssignments | Where-Object {
+                $_.Properties.DisplayName -like "*$script:PolicyDisplayName*" -or
+                $_.Name -like "*$script:PolicyName*" -or
+                $_.Properties.DisplayName -like '*Storage*HTTPS*' -or
+                $_.Properties.DisplayName -like '*Storage*Secure*Transfer*'
+            }
+        }
+
+        It 'Should have policy assigned to resource group' -Skip:($null -eq $script:TargetAssignment) {
+            $script:TargetAssignment | Should -Not -BeNullOrEmpty
+        } -Because 'If policy is not assigned, tests cannot validate compliance. Deploy policy using: terraform apply -var-file=config/vars/sandbox.tfvars.json'
+
+        It 'Should be assigned at resource group scope' {
+            if ($script:TargetAssignment) {
+                $script:TargetAssignment.Properties.Scope | Should -Be $script:ResourceGroup.ResourceId
+            }
+        }
+
+        It 'Should have policy definition associated' {
+            if ($script:TargetAssignment) {
+                $script:TargetAssignment.Properties.PolicyDefinitionId | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        It 'Should have system assigned identity for remediation' {
+            if ($script:TargetAssignment) {
+                $script:TargetAssignment.Identity | Should -Not -BeNullOrEmpty
+                $script:TargetAssignment.Identity.Type | Should -Be 'SystemAssigned'
+            }
+        }
+
+        It 'Should have appropriate parameters configured' {
+            if ($script:TargetAssignment -and $script:TargetAssignment.Properties.Parameters) {
+                $parameters = $script:TargetAssignment.Properties.Parameters
+                $parameters.effect | Should -Not -BeNullOrEmpty
+                $parameters.exemptedStorageAccounts | Should -Not -BeNullOrEmpty
+                $parameters.storageAccountTypes | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}
+
+Describe 'Storage HTTPS-Only Compliance Tests' -Tag @('Integration', 'Slow', 'Compliance') {
+    BeforeAll {
+        # Generate unique names for test storage accounts using centralized function
+        $script:CompliantStorageName = New-PolicyTestResourceName -PolicyCategory 'storage' -PolicyName 'deny-storage-https-disabled' -ResourceType 'compliant'
+        $script:NonCompliantStorageName = New-PolicyTestResourceName -PolicyCategory 'storage' -PolicyName 'deny-storage-https-disabled' -ResourceType 'nonCompliant'
+        $script:ExemptedStorageName = New-PolicyTestResourceName -PolicyCategory 'storage' -PolicyName 'deny-storage-https-disabled' -ResourceType 'exempted'
+    }
+
+    AfterAll {
+        # Cleanup storage accounts
+        foreach ($storageAccount in $script:CreatedStorageAccounts) {
+            try {
+                Write-Host "Cleaning up Storage Account: $($storageAccount.StorageAccountName)" -ForegroundColor Yellow
+                Remove-AzStorageAccount -Name $storageAccount.StorageAccountName -ResourceGroupName $script:ResourceGroupName -Force -ErrorAction SilentlyContinue
+            }
+            catch {
+                Write-Warning "Failed to cleanup Storage Account $($storageAccount.StorageAccountName): $($_.Exception.Message)"
+            }
+        }
+    }
+
+    Context 'Compliant Storage Account (HTTPS Enabled)' {
+        It 'Should successfully create storage account with HTTPS-only enabled' {
+            $storageAccount = New-AzStorageAccount `
+                -ResourceGroupName $script:ResourceGroupName `
+                -Name $script:CompliantStorageName `
+                -Location $script:ResourceGroup.Location `
+                -SkuName $script:TestConfig.Policy.TestConfig.storageAccountSku `
+                -Kind 'StorageV2' `
+                -EnableHttpsTrafficOnly $true `
+                -AllowBlobPublicAccess $false
+
+            $storageAccount | Should -Not -BeNullOrEmpty
+            $storageAccount.EnableHttpsTrafficOnly | Should -Be $true
+            $script:CreatedStorageAccounts += $storageAccount
+        }
+
+        It 'Should verify HTTPS-only is enabled' {
+            $storageAccount = Get-AzStorageAccount -ResourceGroupName $script:ResourceGroupName -Name $script:CompliantStorageName
+            $storageAccount.EnableHttpsTrafficOnly | Should -Be $true
+        }
+
+        It 'Should be compliant with the policy' {
+            # Wait for policy evaluation
+            Start-Sleep -Seconds $script:TestConfig.Timeouts.PolicyEvaluationWaitSeconds
+
+            $complianceStates = Get-AzPolicyState `
+                -ResourceGroupName $script:ResourceGroupName `
+                -Filter "PolicyDefinitionName eq '$script:PolicyName' and ResourceId like '*$script:CompliantStorageName*'"
+
+            if ($complianceStates) {
+                $complianceStates | Should -Not -BeNullOrEmpty
+                $complianceStates[0].ComplianceState | Should -Be 'Compliant'
+            }
+            else {
+                Write-Warning "Policy compliance state not yet available for $script:CompliantStorageName"
+            }
+        }
+    }
+
+    Context 'Non-Compliant Storage Account (HTTPS Disabled)' {
+        It 'Should fail to create storage account with HTTPS-only disabled (in Deny mode)' {
+            # Try to create storage account with HTTPS disabled - this should fail if policy is in Deny mode
+            try {
+                $storageAccount = New-AzStorageAccount `
+                    -ResourceGroupName $script:ResourceGroupName `
+                    -Name $script:NonCompliantStorageName `
+                    -Location $script:ResourceGroup.Location `
+                    -SkuName $script:TestConfig.Policy.TestConfig.storageAccountSku `
+                    -Kind 'StorageV2' `
+                    -EnableHttpsTrafficOnly $false `
+                    -AllowBlobPublicAccess $false `
+                    -ErrorAction Stop
+
+                $script:CreatedStorageAccounts += $storageAccount
+                $createSucceeded = $true
+            }
+            catch {
+                $createSucceeded = $false
+                $createError = $_.Exception.Message
+            }
+
+            # Check policy effect to determine expected behavior
+            if ($script:TargetAssignment -and $script:TargetAssignment.Properties.Parameters.effect.value -eq 'Deny') {
+                $createSucceeded | Should -Be $false
+                $createError | Should -Match 'policy|denied|disallowed|RequestDisallowedByPolicy'
+            }
+            elseif ($script:TargetAssignment -and $script:TargetAssignment.Properties.Parameters.effect.value -eq 'Audit') {
+                # In Audit mode, the operation should succeed but be flagged as non-compliant
+                Write-Warning 'Policy is in Audit mode - Storage account creation succeeded but should be flagged as non-compliant'
+                $createSucceeded | Should -Be $true
+            }
+        }
+
+        It 'Should be flagged as non-compliant (in Audit mode)' {
+            # Only test compliance in Audit mode
+            if ($script:TargetAssignment -and $script:TargetAssignment.Properties.Parameters.effect.value -eq 'Audit') {
+                # Wait for policy evaluation
+                Start-Sleep -Seconds $script:TestConfig.Timeouts.PolicyEvaluationWaitSeconds
+
+                $complianceStates = Get-AzPolicyState `
+                    -ResourceGroupName $script:ResourceGroupName `
+                    -Filter "PolicyDefinitionName eq '$script:PolicyName' and ResourceId like '*$script:NonCompliantStorageName*'"
+
+                if ($complianceStates) {
+                    $complianceStates | Should -Not -BeNullOrEmpty
+                    $complianceStates[0].ComplianceState | Should -Be 'NonCompliant'
+                }
+                else {
+                    Write-Warning "Policy compliance state not yet available for $script:NonCompliantStorageName"
+                }
+            }
+        }
+    }
+
+    Context 'Exempted Storage Account' {
+        It 'Should create exempted storage account successfully even with HTTPS disabled' {
+            # Check if there are exempted storage accounts configured
+            $exemptedAccounts = @()
+            if ($script:TargetAssignment -and $script:TargetAssignment.Properties.Parameters.exemptedStorageAccounts) {
+                $exemptedAccounts = $script:TargetAssignment.Properties.Parameters.exemptedStorageAccounts.value
+            }
+
+            if ($exemptedAccounts -contains $script:ExemptedStorageName) {
+                # Create storage account with HTTPS disabled - should succeed for exempted accounts
+                $storageAccount = New-AzStorageAccount `
+                    -ResourceGroupName $script:ResourceGroupName `
+                    -Name $script:ExemptedStorageName `
+                    -Location $script:ResourceGroup.Location `
+                    -SkuName $script:TestConfig.Policy.TestConfig.storageAccountSku `
+                    -Kind 'StorageV2' `
+                    -EnableHttpsTrafficOnly $false `
+                    -AllowBlobPublicAccess $false
+
+                $storageAccount | Should -Not -BeNullOrEmpty
+                $storageAccount.EnableHttpsTrafficOnly | Should -Be $false
+                $script:CreatedStorageAccounts += $storageAccount
+            }
+            else {
+                Write-Warning 'No exempted storage accounts configured - skipping exemption test'
+            }
+        }
+    }
+
+    Context 'Updating Existing Storage Account' {
+        It 'Should allow updating compliant storage account' {
+            # Verify we can update a compliant storage account (with HTTPS enabled)
+            $existingAccount = Get-AzStorageAccount -ResourceGroupName $script:ResourceGroupName -Name $script:CompliantStorageName
+
+            # Add a tag to verify update capability
+            Set-AzStorageAccount `
+                -ResourceGroupName $script:ResourceGroupName `
+                -Name $script:CompliantStorageName `
+                -Tag @{TestTag = 'TestValue'; UpdatedBy = 'PesterTest' } `
+                -ErrorAction Stop
+
+            $updatedAccount = Get-AzStorageAccount -ResourceGroupName $script:ResourceGroupName -Name $script:CompliantStorageName
+            $updatedAccount.Tags['TestTag'] | Should -Be 'TestValue'
+        }
+
+        It 'Should prevent disabling HTTPS on existing storage account (in Deny mode)' {
+            # Try to disable HTTPS on an existing account - should fail if policy is in Deny mode
+            try {
+                Set-AzStorageAccount `
+                    -ResourceGroupName $script:ResourceGroupName `
+                    -Name $script:CompliantStorageName `
+                    -EnableHttpsTrafficOnly $false `
+                    -ErrorAction Stop
+
+                $updateSucceeded = $true
+            }
+            catch {
+                $updateSucceeded = $false
+                $updateError = $_.Exception.Message
+            }
+
+            # Check policy effect
+            if ($script:TargetAssignment -and $script:TargetAssignment.Properties.Parameters.effect.value -eq 'Deny') {
+                $updateSucceeded | Should -Be $false
+                $updateError | Should -Match 'policy|denied|disallowed|RequestDisallowedByPolicy'
+            }
+            elseif ($script:TargetAssignment -and $script:TargetAssignment.Properties.Parameters.effect.value -eq 'Audit') {
+                Write-Warning 'Policy is in Audit mode - Update succeeded but should be flagged as non-compliant'
+            }
+        }
+    }
+}
+
+Describe 'Policy Effectiveness Tests' -Tag @('Integration', 'Slow', 'Effectiveness') {
+    Context 'HTTPS-Only Configuration Validation' {
+        It 'Should validate policy targets correct HTTPS settings' {
+            $policyRule = $script:PolicyDefinitionJson.properties.policyRule
+            $conditions = $policyRule.if.allOf
+            $httpsCondition = $conditions | Where-Object { $_.anyOf }
+
+            $httpsCondition | Should -Not -BeNullOrEmpty
+            $httpsChecks = $httpsCondition.anyOf
+
+            # Should check if supportsHttpsTrafficOnly exists
+            $existsCheck = $httpsChecks | Where-Object {
+                $_.field -eq 'Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly' -and $_.exists -eq 'false'
+            }
+            $existsCheck | Should -Not -BeNullOrEmpty
+
+            # Should check if supportsHttpsTrafficOnly is false
+            $falseCheck = $httpsChecks | Where-Object {
+                $_.field -eq 'Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly' -and $_.equals -eq 'false'
+            }
+            $falseCheck | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should not affect other resource types' {
+            $policyRule = $script:PolicyDefinitionJson.properties.policyRule
+            $conditions = $policyRule.if.allOf
+
+            $typeCondition = $conditions | Where-Object { $_.field -eq 'type' }
+            $typeCondition.equals | Should -Be 'Microsoft.Storage/storageAccounts'
+        }
+
+        It 'Should respect exemptions properly' {
+            $policyRule = $script:PolicyDefinitionJson.properties.policyRule
+            $conditions = $policyRule.if.allOf
+
+            # Check storage account exemptions
+            $exemption = $conditions | Where-Object {
+                $_.not -and $_.not.field -eq 'name'
+            }
+            $exemption | Should -Not -BeNullOrEmpty
+            $exemption.not.in | Should -Be '[parameters(''exemptedStorageAccounts'')]'
+        }
+
+        It 'Should apply to configured storage account types' {
+            $policyRule = $script:PolicyDefinitionJson.properties.policyRule
+            $conditions = $policyRule.if.allOf
+
+            $skuCondition = $conditions | Where-Object {
+                $_.field -eq 'Microsoft.Storage/storageAccounts/sku.name'
+            }
+            $skuCondition | Should -Not -BeNullOrEmpty
+            $skuCondition.in | Should -Be '[parameters(''storageAccountTypes'')]'
+        }
+    }
+
+    Context 'Policy Integration' {
+        It 'Should work with Terraform deployment' {
+            $terraformPath = Join-Path $PSScriptRoot '..\..\policies\storage\deny-storage-https-disabled'
+
+            Test-Path (Join-Path $terraformPath 'main.tf') | Should -Be $true
+            Test-Path (Join-Path $terraformPath 'variables.tf') | Should -Be $true
+            Test-Path (Join-Path $terraformPath 'outputs.tf') | Should -Be $true
+        }
+
+        It 'Should have consistent naming across files' {
+            $terraformVarsPath = Join-Path $PSScriptRoot '..\..\policies\storage\deny-storage-https-disabled\variables.tf'
+
+            if (Test-Path $terraformVarsPath) {
+                $varsContent = Get-Content $terraformVarsPath -Raw
+                $varsContent | Should -Match 'deny-storage-https-disabled'
+            }
+        }
+    }
+}
+
+Describe 'Security Validation' -Tag @('Security', 'Fast') {
+    Context 'HTTPS Enforcement Security' {
+        It 'Should enforce encryption in transit' {
+            $description = $script:PolicyDefinitionJson.properties.description
+            $description | Should -Match 'HTTPS|secure|encrypt'
+        }
+
+        It 'Should prevent unencrypted data transfer' {
+            $description = $script:PolicyDefinitionJson.properties.description
+            $description | Should -Match 'secure transport|encrypted'
+        }
+
+        It 'Should have appropriate security metadata' {
+            $metadata = $script:PolicyDefinitionJson.properties.metadata
+            $metadata.category | Should -Be 'Storage'
+        }
+    }
+
+    Context 'Policy Parameter Security' {
+        It 'Should have secure default effect' {
+            $effectParam = $script:PolicyDefinitionJson.properties.parameters.effect
+            $effectParam.defaultValue | Should -Be 'Deny'
+        }
+
+        It 'Should allow controlled exemptions' {
+            $exemptionsParam = $script:PolicyDefinitionJson.properties.parameters.exemptedStorageAccounts
+            $exemptionsParam.type | Should -Be 'Array'
+            $exemptionsParam.defaultValue | Should -Be @()
+        }
+
+        It 'Should apply to multiple storage account types' {
+            $typesParam = $script:PolicyDefinitionJson.properties.parameters.storageAccountTypes
+            $typesParam.defaultValue.Count | Should -BeGreaterThan 5
+        }
+    }
+}
+
+Write-Host "`nTest Summary:" -ForegroundColor Cyan
+Write-Host "- Policy Name: $script:PolicyName" -ForegroundColor Green
+Write-Host "- Policy Display Name: $script:PolicyDisplayName" -ForegroundColor Green
+Write-Host "- Resource Group: $script:ResourceGroupName" -ForegroundColor Green
+Write-Host "- Subscription: $($script:Context.Subscription.Name) ($script:SubscriptionId)" -ForegroundColor Green
+
+if ($script:TargetAssignment) {
+    Write-Host "- Policy Assignment Found: $($script:TargetAssignment.Name)" -ForegroundColor Green
+    Write-Host "- Policy Effect: $($script:TargetAssignment.Properties.Parameters.effect.value)" -ForegroundColor Green
+}
+else {
+    Write-Host '- Policy Assignment: Not Found' -ForegroundColor Yellow
+}

--- a/tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1
+++ b/tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1
@@ -1,0 +1,410 @@
+#Requires -Modules Pester
+
+<#
+.SYNOPSIS
+    Quick unit tests for Azure Policy deny-storage-https-disabled (no Azure resources required)
+.DESCRIPTION
+    This test suite validates Azure Policy JSON definitions without requiring
+    Azure authentication or resource creation. Perfect for quick validation.
+.NOTES
+    Prerequisites:
+    - Pester module only
+    - No Azure authentication required
+    - No Azure resources created
+#>
+
+BeforeAll {
+    # Import centralized configuration
+    . "$PSScriptRoot\..\..\config\config-loader.ps1"
+
+    # Initialize test configuration for this specific policy
+    $script:TestConfig = Initialize-PolicyTestConfig -PolicyCategory 'storage' -PolicyName 'deny-storage-https-disabled'
+
+    # Set script variables from configuration
+    $script:PolicyPath = Get-PolicyDefinitionPath -PolicyCategory 'storage' -PolicyName 'deny-storage-https-disabled' -TestScriptPath $PSScriptRoot
+    $script:ExpectedPolicyName = $script:TestConfig.Policy.Name
+    $script:ExpectedDisplayName = $script:TestConfig.Policy.DisplayName
+}
+
+Describe 'Policy JSON Validation' -Tag @('Unit', 'Fast', 'Static') {
+
+    Context 'File Structure' {
+        It 'Should have policy definition file' {
+            Test-Path $script:PolicyPath | Should -Be $true
+        }
+
+        It 'Should be valid JSON' {
+            { Get-Content $script:PolicyPath -Raw | ConvertFrom-Json } | Should -Not -Throw
+        }
+    }
+
+    Context 'Policy Content Validation' {
+        BeforeAll {
+            $script:PolicyJson = Get-Content $script:PolicyPath -Raw | ConvertFrom-Json
+        }
+
+        It 'Should have properties section' {
+            $script:PolicyJson.properties | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have correct policy name' {
+            $script:PolicyJson.name | Should -Be $script:ExpectedPolicyName
+        }
+
+        It 'Should have display name' {
+            $script:PolicyJson.properties.displayName | Should -Match 'HTTPS'
+        }
+
+        It 'Should have description' {
+            $script:PolicyJson.properties.description | Should -Not -BeNullOrEmpty
+            $script:PolicyJson.properties.description.Length | Should -BeGreaterThan 10
+            $script:PolicyJson.properties.description | Should -Match 'HTTPS'
+        }
+
+        It 'Should have mode set to All' {
+            $script:PolicyJson.properties.mode | Should -Be 'All'
+        }
+
+        It 'Should have policy rule' {
+            $script:PolicyJson.properties.policyRule | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have metadata section' {
+            $script:PolicyJson.properties.metadata | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have parameters section' {
+            $script:PolicyJson.properties.parameters | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Policy Rule Validation' {
+        BeforeAll {
+            $script:PolicyRule = (Get-Content $script:PolicyPath -Raw | ConvertFrom-Json).properties.policyRule
+        }
+
+        It 'Should have if condition' {
+            $script:PolicyRule.if | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have then effect' {
+            $script:PolicyRule.then | Should -Not -BeNullOrEmpty
+            $script:PolicyRule.then.effect | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should target storage accounts' {
+            $resourceTypeCondition = $script:PolicyRule.if.allOf | Where-Object {
+                $_.field -eq 'type' -and $_.equals -eq 'Microsoft.Storage/storageAccounts'
+            }
+            $resourceTypeCondition | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should check supportsHttpsTrafficOnly property' {
+            $anyOfCondition = $script:PolicyRule.if.allOf | Where-Object { $_.anyOf }
+            $anyOfCondition | Should -Not -BeNullOrEmpty
+
+            $httpsConditions = $anyOfCondition.anyOf
+
+            # Should check if property exists
+            $existsCheck = $httpsConditions | Where-Object {
+                $_.field -eq 'Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly' -and $_.exists -eq 'false'
+            }
+            $existsCheck | Should -Not -BeNullOrEmpty
+
+            # Should check if property is false
+            $falseCheck = $httpsConditions | Where-Object {
+                $_.field -eq 'Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly' -and $_.equals -eq 'false'
+            }
+            $falseCheck | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should use anyOf for HTTPS property conditions' {
+            $anyOfCondition = $script:PolicyRule.if.allOf | Where-Object { $_.anyOf }
+            $anyOfCondition | Should -Not -BeNullOrEmpty
+            $anyOfCondition.anyOf.Count | Should -BeGreaterOrEqual 2
+        }
+
+        It 'Should have parameterized effect' {
+            $effect = $script:PolicyRule.then.effect
+            $effect | Should -Match '^\[parameters\('
+        }
+    }
+
+    Context 'Policy Parameters Validation' {
+        BeforeAll {
+            $script:Parameters = (Get-Content $script:PolicyPath -Raw | ConvertFrom-Json).properties.parameters
+        }
+
+        It 'Should have effect parameter' {
+            $script:Parameters.effect | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should have valid effect allowed values' {
+            $effectParam = $script:Parameters.effect
+            $effectParam.allowedValues | Should -Contain 'Audit'
+            $effectParam.allowedValues | Should -Contain 'Deny'
+            $effectParam.allowedValues | Should -Contain 'Disabled'
+        }
+
+        It 'Should have Deny as default effect' {
+            $script:Parameters.effect.defaultValue | Should -Be 'Deny'
+        }
+
+        It 'Should have exemptedStorageAccounts parameter' {
+            $script:Parameters.exemptedStorageAccounts | Should -Not -BeNullOrEmpty
+            $script:Parameters.exemptedStorageAccounts.type | Should -Be 'Array'
+        }
+
+        It 'Should have empty or null default for exemptedStorageAccounts' {
+            $exemptionsParam = $script:Parameters.exemptedStorageAccounts
+            $exemptions = $exemptionsParam.defaultValue
+
+            # Default value should be either empty array or null (both acceptable for no exemptions)
+            if ($null -eq $exemptions) {
+                # Null/empty is valid - no exemptions by default
+                $null -eq $exemptions | Should -Be $true
+            }
+            else {
+                # If not null, should be empty array
+                $exemptions.GetType().BaseType.Name | Should -Be 'Array'
+                $exemptions.Count | Should -Be 0
+            }
+        }
+
+        It 'Should have storageAccountTypes parameter' {
+            $script:Parameters.storageAccountTypes | Should -Not -BeNullOrEmpty
+            $script:Parameters.storageAccountTypes.type | Should -Be 'Array'
+        }
+
+        It 'Should have valid storage account types in allowed values' {
+            $allowedTypes = $script:Parameters.storageAccountTypes.allowedValues
+            $allowedTypes | Should -Contain 'Standard_LRS'
+            $allowedTypes | Should -Contain 'Standard_GRS'
+            $allowedTypes | Should -Contain 'Premium_LRS'
+        }
+
+        It 'Should check storage account type in policy rule' {
+            $skuCondition = $script:PolicyRule.if.allOf | Where-Object {
+                $_.field -eq 'Microsoft.Storage/storageAccounts/sku.name'
+            }
+            $skuCondition | Should -Not -BeNullOrEmpty
+            $skuCondition.in | Should -Match '^\[parameters\('
+        }
+
+        It 'Should check exempted storage accounts in policy rule' {
+            $exemptionCondition = $script:PolicyRule.if.allOf | Where-Object {
+                $_.not -and $_.not.field -eq 'name'
+            }
+            $exemptionCondition | Should -Not -BeNullOrEmpty
+            $exemptionCondition.not.in | Should -Match '^\[parameters\('
+        }
+    }
+
+    Context 'Policy Metadata Validation' {
+        BeforeAll {
+            $script:Metadata = (Get-Content $script:PolicyPath -Raw | ConvertFrom-Json).properties.metadata
+        }
+
+        It 'Should have category' {
+            $script:Metadata.category | Should -Be 'Storage'
+        }
+
+        It 'Should have version' {
+            $script:Metadata.version | Should -Not -BeNullOrEmpty
+            $script:Metadata.version | Should -Match '^\d+\.\d+\.\d+$'
+        }
+
+        It 'Should have source in metadata' {
+            $script:Metadata.source | Should -Not -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Policy Logic Validation' -Tag @('Unit', 'Fast', 'Logic') {
+
+    BeforeAll {
+        $script:PolicyJson = Get-Content $script:PolicyPath -Raw | ConvertFrom-Json
+        $script:PolicyRule = $script:PolicyJson.properties.policyRule
+    }
+
+    Context 'Condition Logic' {
+        It 'Should use allOf for combining conditions' {
+            $script:PolicyRule.if.allOf | Should -Not -BeNullOrEmpty
+            $script:PolicyRule.if.allOf.Count | Should -BeGreaterThan 2
+        }
+
+        It 'Should have proper boolean logic structure' {
+            $conditions = $script:PolicyRule.if.allOf
+
+            # Should have resource type condition
+            $typeCondition = $conditions | Where-Object { $_.field -eq 'type' }
+            $typeCondition | Should -Not -BeNullOrEmpty
+
+            # Should have SKU condition
+            $skuCondition = $conditions | Where-Object { $_.field -eq 'Microsoft.Storage/storageAccounts/sku.name' }
+            $skuCondition | Should -Not -BeNullOrEmpty
+
+            # Should have exemption condition
+            $exemptionCondition = $conditions | Where-Object { $_.not }
+            $exemptionCondition | Should -Not -BeNullOrEmpty
+
+            # Should have anyOf condition for HTTPS property
+            $anyOfCondition = $conditions | Where-Object { $_.anyOf }
+            $anyOfCondition | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Should properly structure the anyOf conditions for HTTPS' {
+            $anyOfCondition = $script:PolicyRule.if.allOf | Where-Object { $_.anyOf }
+            $anyOfConditions = $anyOfCondition.anyOf
+
+            # Should have 2 conditions in anyOf (exists check and value check)
+            $anyOfConditions.Count | Should -Be 2
+
+            # Should have condition for property existence
+            $existsCondition = $anyOfConditions | Where-Object {
+                $_.field -eq 'Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly' -and $_.exists -eq 'false'
+            }
+            $existsCondition | Should -Not -BeNullOrEmpty
+
+            # Should have condition for property value
+            $valueCondition = $anyOfConditions | Where-Object {
+                $_.field -eq 'Microsoft.Storage/storageAccounts/supportsHttpsTrafficOnly' -and $_.equals -eq 'false'
+            }
+            $valueCondition | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Security Logic' {
+        It 'Should enforce HTTPS-only traffic by default' {
+            $effectParam = $script:PolicyJson.properties.parameters.effect
+            $effectParam.defaultValue | Should -Be 'Deny'
+        }
+
+        It 'Should protect against unencrypted traffic' {
+            $description = $script:PolicyJson.properties.description
+            $description | Should -Match 'HTTPS|secure|encrypt'
+        }
+    }
+}
+
+Describe 'Policy Compliance Scenarios' -Tag @('Unit', 'Fast', 'Scenarios') {
+
+    BeforeAll {
+        $script:PolicyJson = Get-Content $script:PolicyPath -Raw | ConvertFrom-Json
+        $script:PolicyRule = $script:PolicyJson.properties.policyRule
+    }
+
+    Context 'Simulated Resource Evaluation' {
+        It 'Should identify compliant storage account (HTTPS enabled)' {
+            # Simulate a compliant storage account
+            $compliantResource = @{
+                type       = 'Microsoft.Storage/storageAccounts'
+                name       = 'compliantsa001'
+                properties = @{
+                    supportsHttpsTrafficOnly = $true
+                }
+                sku        = @{
+                    name = 'Standard_LRS'
+                }
+            }
+
+            # This is a conceptual test - in real scenarios, Azure Policy engine evaluates this
+            # We're testing our understanding of what should be compliant
+            $compliantResource.properties.supportsHttpsTrafficOnly | Should -Be $true
+        }
+
+        It 'Should identify non-compliant storage account (HTTPS disabled)' {
+            # Simulate a non-compliant storage account (HTTPS disabled)
+            $nonCompliantResource = @{
+                type       = 'Microsoft.Storage/storageAccounts'
+                name       = 'noncomplientsa001'
+                properties = @{
+                    supportsHttpsTrafficOnly = $false
+                }
+                sku        = @{
+                    name = 'Standard_LRS'
+                }
+            }
+
+            # This resource should trigger the policy due to HTTPS being disabled
+            $nonCompliantResource.properties.supportsHttpsTrafficOnly | Should -Be $false
+        }
+
+        It 'Should identify non-compliant storage account (HTTPS property missing)' {
+            # Simulate a non-compliant storage account (property not set)
+            $nonCompliantResource = @{
+                type       = 'Microsoft.Storage/storageAccounts'
+                name       = 'missingpropsa001'
+                properties = @{
+                    # supportsHttpsTrafficOnly property is missing
+                }
+                sku        = @{
+                    name = 'Standard_LRS'
+                }
+            }
+
+            # This resource should trigger the policy due to missing HTTPS property
+            $nonCompliantResource.properties.ContainsKey('supportsHttpsTrafficOnly') | Should -Be $false
+        }
+
+        It 'Should respect exempted storage accounts' {
+            # Simulate an exempted storage account
+            $exemptedResource = @{
+                type       = 'Microsoft.Storage/storageAccounts'
+                name       = 'exemptedsa001'
+                properties = @{
+                    supportsHttpsTrafficOnly = $false
+                }
+                sku        = @{
+                    name = 'Standard_LRS'
+                }
+            }
+
+            # In the policy, if this account is in exemptedStorageAccounts parameter,
+            # it should not trigger the policy even with HTTPS disabled
+            $exemptedResource.name | Should -Be 'exemptedsa001'
+        }
+
+        It 'Should apply to all configured storage account types' {
+            $storageTypes = $script:PolicyJson.properties.parameters.storageAccountTypes.defaultValue
+
+            # Should include common storage types
+            $storageTypes | Should -Contain 'Standard_LRS'
+            $storageTypes | Should -Contain 'Standard_GRS'
+            $storageTypes | Should -Contain 'Premium_LRS'
+
+            # Should have multiple types configured
+            $storageTypes.Count | Should -BeGreaterThan 5
+        }
+    }
+}
+
+Describe 'Terraform Integration' -Tag @('Unit', 'Fast', 'Terraform') {
+
+    Context 'Terraform Files' {
+        It 'Should have main.tf file' {
+            $terraformPath = Join-Path $PSScriptRoot '..\..\policies\storage\deny-storage-https-disabled'
+            Test-Path (Join-Path $terraformPath 'main.tf') | Should -Be $true
+        }
+
+        It 'Should have variables.tf file' {
+            $terraformPath = Join-Path $PSScriptRoot '..\..\policies\storage\deny-storage-https-disabled'
+            Test-Path (Join-Path $terraformPath 'variables.tf') | Should -Be $true
+        }
+
+        It 'Should have outputs.tf file' {
+            $terraformPath = Join-Path $PSScriptRoot '..\..\policies\storage\deny-storage-https-disabled'
+            Test-Path (Join-Path $terraformPath 'outputs.tf') | Should -Be $true
+        }
+
+        It 'Should have consistent naming in Terraform files' {
+            $terraformPath = Join-Path $PSScriptRoot '..\..\policies\storage\deny-storage-https-disabled'
+            $varsPath = Join-Path $terraformPath 'variables.tf'
+
+            if (Test-Path $varsPath) {
+                $varsContent = Get-Content $varsPath -Raw
+                $varsContent | Should -Match 'deny-storage-https-disabled'
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request updates the `.secrets.baseline` file to include newly detected high-entropy strings (potential secrets) in two test files related to storage HTTPS enforcement. These updates help ensure that any sensitive information in test scripts is tracked and flagged for review.

**Secret detection updates:**

* Added multiple "Base64 High Entropy String" entries for potential secrets found in `tests/storage/Storage.Integration-DenyStorageHttpsDisabled.Tests.ps1`, including line numbers and hashed values for each detected string.
* Added similar "Base64 High Entropy String" entries for `tests/storage/Storage.Unit-DenyStorageHttpsDisabled.Tests.ps1`, with details for each detected string.

**Metadata update:**

* Updated the `generated_at` timestamp in `.secrets.baseline` to reflect the latest scan time.